### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,7 @@ Changes
 1.5.0
 -----
 
-- Made ``MemcachedProviderFactory`` configureable. Defaults behave like in prior
+- Made ``MemcachedProviderFactory`` configurable. Defaults behave like in prior
   versions. New: We can pass ``server=`` keyword argument to the 
   constructor expecting a list of servers, each in the form *server:port*.
   (jensens, 2009-12-30)


### PR DESCRIPTION
@bluedynamics, I've corrected a typographical error in the documentation of the [bda.ldap](https://github.com/bluedynamics/bda.ldap) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
